### PR TITLE
Downloading GAIA files during setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .vscode
 
 .DS_Store
+
+.datasets

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This repo is used to run various AI benchmarks on the [Open Interpreter project]
 ```bash
 git clone https://github.com/imapersonman/oi-benchmarks.git \
   && cd oi-benchmarks \
+  && python -m venv .venv
+  && source .venv/bin/activate
+  && python -m pip install -r requirements.txt
+  && docker build -t worker .
   && python setup.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ This repo is used to run various AI benchmarks on the [Open Interpreter project]
 ```bash
 git clone https://github.com/imapersonman/oi-benchmarks.git \
   && cd oi-benchmarks \
-  && python -m venv .venv \
-  && source .venv/bin/activate \
-  && python -m pip install -r requirements.txt \
-  && docker build -t worker .
+  && python setup.py
 ```
 
 4. Use your [Huggingface Access Token](https://huggingface.co/docs/hub/en/security-tokens) to login using the `huggingface-cli`.
     - This is only necessary if you're running huggingface-hosted benchmarks, like GAIA.  If you want to run non-huggingface-hosted benchmarks, or if our AI overlords have succesfully ushered us into a post-access token utopia, please disregard this step.
+
+4. Download 
 
 ```bash
 huggingface-cli login

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This repo is used to run various AI benchmarks on the [Open Interpreter project]
 ```bash
 git clone https://github.com/imapersonman/oi-benchmarks.git \
   && cd oi-benchmarks \
-  && python -m venv .venv
-  && source .venv/bin/activate
-  && python -m pip install -r requirements.txt
-  && docker build -t worker .
+  && python -m venv .venv \
+  && source .venv/bin/activate \
+  && python -m pip install -r requirements.txt \
+  && docker build -t worker . \
   && python setup.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,12 @@ This repo is used to run various AI benchmarks on the [Open Interpreter project]
 - [Python](https://www.python.org)
 - [Docker](https://www.docker.com/)
 
-3. Copy-paste the following lines into your terminal if you're feeling dangerous.
+2. Copy-paste the following lines into your terminal if you're feeling dangerous.
 
 ```bash
 git clone https://github.com/imapersonman/oi-benchmarks.git \
   && cd oi-benchmarks \
   && python setup.py
-```
-
-4. Use your [Huggingface Access Token](https://huggingface.co/docs/hub/en/security-tokens) to login using the `huggingface-cli`.
-    - This is only necessary if you're running huggingface-hosted benchmarks, like GAIA.  If you want to run non-huggingface-hosted benchmarks, or if our AI overlords have succesfully ushered us into a post-access token utopia, please disregard this step.
-
-4. Download 
-
-```bash
-huggingface-cli login
 ```
 
 ## Running Benchmarks

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@ import subprocess
 from pathlib import Path
 
 
+"""
+This script is responsible for downloading benchmarks.  It's imperative that the files this script
+downloads are NOT committed to this repository.
+"""
+
+
 color = lambda c: lambda s: f"\\033[{c}m{s}\\033[0m"
 red = color(91)
 green = color(92)
@@ -14,9 +20,10 @@ def run_cmd(cmd: str):
 print(green("logging into huggingface"))
 run_cmd("huggingface-cli login")
 
-if not Path(".datasets"):
+datasets = Path(".datasets")
+if not datasets.exists():
     print(green("creating .datasets directory"))
-    run_cmd("mkdir -p .datasets")
+    datasets.mkdir(parents=True)
 
 if not Path(".datasets/GAIA").exists():
     print(green("downloading gaia"))

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ downloads are NOT committed to this repository.
 """
 
 
-color = lambda c: lambda s: f"\\033[{c}m{s}\\033[0m"
+color = lambda c: lambda s: f"\033[{c}m{s}\033[0m"
 red = color(91)
 green = color(92)
 
 
 def run_cmd(cmd: str):
-    subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    subprocess.run(cmd.split(" "), check=True)
 
 
 print(green("logging into huggingface"))

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ assert program_exists("git"), "Install git before re-running this script."
 run_cmd("creating virtual environment", "python -m venv .venv", iff=not Path(".venv").exists())
 run_cmd("activating virtual environment", "source .venv/bin/activate", iff=not in_venv())
 run_cmd("installing requirements", "python -m pip install -r requirements.txt")
-run_cmd("building docker container", "docker build -t worker .")
+run_cmd("logging into huggingface", "huggingface-cli login")
 run_cmd("creating .datasets directory", "mkdir -p .datasets", iff=not Path(".datasets").exists())
 run_cmd("downloading gaia", "git clone https://huggingface.co/datasets/gaia-benchmark/GAIA .datasets/GAIA", iff=not Path(".datasets/GAIA").exists())
+run_cmd("building docker container", "docker build -t worker .")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+import sys
+import subprocess
+import shutil
+from pathlib import Path
+
+
+color = lambda c: lambda s: f"\\033[{c}m{s}\\033[0m"
+red = color(91)
+green = color(92)
+
+def run_cmd(description: str, cmd: str, iff: bool = True):
+    if iff:
+        print(green(description))
+        subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+
+def program_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+def in_venv() -> bool:
+    return sys.prefix != sys.base_prefix
+
+
+assert program_exists("docker"), "Install docker before re-running this script."
+assert program_exists("git"), "Install git before re-running this script."
+
+run_cmd("creating virtual environment", "python -m venv .venv", iff=not Path(".venv").exists())
+run_cmd("activating virtual environment", "source .venv/bin/activate", iff=not in_venv())
+run_cmd("installing requirements", "python -m pip install -r requirements.txt")
+run_cmd("building docker container", "docker build -t worker .")
+run_cmd("creating .datasets directory", "mkdir -p .datasets", iff=not Path(".datasets").exists())
+run_cmd("downloading gaia", "git clone https://huggingface.co/datasets/gaia-benchmark/GAIA .datasets/GAIA", iff=not Path(".datasets/GAIA").exists())

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,23 @@
-import sys
 import subprocess
-import shutil
 from pathlib import Path
 
 
-color = lambda c: lambda s: f"\033[{c}m{s}\033[0m"
+color = lambda c: lambda s: f"\\033[{c}m{s}\\033[0m"
 red = color(91)
 green = color(92)
 
-def run_cmd(description: str, cmd: str, iff: bool = True):
-    if iff:
-        print(green(description))
-        subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
-def program_exists(name: str) -> bool:
-    return shutil.which(name) is not None
-
-def in_venv() -> bool:
-    return sys.prefix != sys.base_prefix
+def run_cmd(cmd: str):
+    subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
 
-assert program_exists("docker"), "Install docker before re-running this script."
-assert program_exists("git"), "Install git before re-running this script."
+print(green("logging into huggingface"))
+run_cmd("huggingface-cli login")
 
-run_cmd("creating virtual environment", "python -m venv .venv", iff=not Path(".venv").exists())
-run_cmd("activating virtual environment", "source .venv/bin/activate", iff=not in_venv())
-run_cmd("installing requirements", "python -m pip install -r requirements.txt")
-run_cmd("logging into huggingface", "huggingface-cli login")
-run_cmd("creating .datasets directory", "mkdir -p .datasets", iff=not Path(".datasets").exists())
-run_cmd("downloading gaia", "git clone https://huggingface.co/datasets/gaia-benchmark/GAIA .datasets/GAIA", iff=not Path(".datasets/GAIA").exists())
-run_cmd("building docker container", "docker build -t worker .")
+if not Path(".datasets"):
+    print(green("creating .datasets directory"))
+    run_cmd("mkdir -p .datasets")
+
+if not Path(".datasets/GAIA").exists():
+    print(green("downloading gaia"))
+    run_cmd("git clone https://huggingface.co/datasets/gaia-benchmark/GAIA .datasets/GAIA")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 
-color = lambda c: lambda s: f"\\033[{c}m{s}\\033[0m"
+color = lambda c: lambda s: f"\033[{c}m{s}\033[0m"
 red = color(91)
 green = color(92)
 

--- a/test.py
+++ b/test.py
@@ -2,5 +2,5 @@ import os
 import benchmark
 
 runner = benchmark.DockerBenchmarkRunner()
-messages = runner.run({"auto_run": True, "api_key": os.environ.get("OPENAI_API_KEY", "")}, "sleep for 2 seconds", True)
+messages = runner.run(lambda _: None, {"auto_run": True, "api_key": os.environ.get("OPENAI_API_KEY", "")}, "sleep for 2 seconds", True)
 print(messages)

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, cast
 from interpreter import OpenInterpreter
 
 
-OUTPUT_PATH = Path("messages.json")
+OUTPUT_PATH = Path("output/messages.json")
 
 
 def command_to_interpreter(cmd: Dict[str, Any]) -> OpenInterpreter:

--- a/worker/run.py
+++ b/worker/run.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     print("prompt:", prompt)
 
     # running!
-    full_output_path = out_dir / OUTPUT_PATH
+    full_output_path = OUTPUT_PATH
     messages = run(command_config_as_json, prompt, True)
     if not full_output_path.parent.exists():
         os.makedirs(full_output_path.parent)


### PR DESCRIPTION
## Problem

We're using [huggingface's datasets library](https://github.com/huggingface/datasets) to query [GAIA benchmarks](https://huggingface.co/datasets/gaia-benchmark/GAIA), but [GAIA doesn't seem to handle files correctly](https://discuss.huggingface.co/t/how-to-resolve-file-paths-in-a-downloaded-dataset/76611).

## Solution

This PR "fixes" the issue by directing users of `oi-benchmarks` to clone the GAIA repository during setup.  Changes include:

- an amendment to the setup process that includes running a [script that clones GAIA](https://github.com/imapersonman/oi-benchmarks/blob/611bb75e0f1cad83cc3efdeb5a846f11cd2180b2/setup.py) when the repo is initially cloned, and
- a handful of hacks that make it possible to change the docker image's filesytem to accommodate extra files.
    - There is a risk that these hacks couple Gaia benchmarks to the code that runs docker.  Time will tell how much of an issue this is.