### PR TITLE
Local saves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 
 .DS_Store
 
-.datasets
+.local

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+LOCAL = Path(".local")
+DATASETS = LOCAL / Path("datasets")
+GAIA = DATASETS / Path("GAIA")

--- a/gaia.py
+++ b/gaia.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, TypedDict, cast
 from datasets import load_dataset
 
 from benchmark import Benchmark, ResultStatus, ZeroShotTask
+from constants import DATASETS, GAIA
 
 
 GAIATask = TypedDict("GAIATask", {
@@ -20,7 +21,7 @@ GAIATask = TypedDict("GAIATask", {
 
 def benchmark(first_n: Optional[int] = None) -> Benchmark[GAIATask]:
     def get_tasks() -> List[GAIATask]:
-        ds = load_dataset("./.datasets/GAIA", "2023_all", split="validation", data_dir="./datasets", trust_remote_code=True)
+        ds = load_dataset(str(GAIA), "2023_all", split="validation", data_dir=str(DATASETS), trust_remote_code=True)
         tasks = cast(List[GAIATask], list(ds))
         n_tasks = first_n or len(tasks)
         return tasks[:n_tasks]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import subprocess
 from pathlib import Path
 
+from constants import DATASETS, GAIA
+
 
 """
 This script is responsible for downloading benchmarks.  It's imperative that the files this script
@@ -20,11 +22,11 @@ def run_cmd(cmd: str):
 print(green("logging into huggingface"))
 run_cmd("huggingface-cli login")
 
-datasets = Path(".datasets")
-if not datasets.exists():
-    print(green("creating .datasets directory"))
-    datasets.mkdir(parents=True)
 
-if not Path(".datasets/GAIA").exists():
+if not DATASETS.exists():
+    print(green(f"creating datasets directory at {DATASETS}"))
+    DATASETS.mkdir(parents=True)
+
+if not GAIA.exists():
     print(green("downloading gaia"))
-    run_cmd("git clone https://huggingface.co/datasets/gaia-benchmark/GAIA .datasets/GAIA")
+    run_cmd(f"git clone https://huggingface.co/datasets/gaia-benchmark/GAIA {GAIA}")

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-import os
-import benchmark
-
-runner = benchmark.DockerBenchmarkRunner()
-messages = runner.run(lambda _: None, {"auto_run": True, "api_key": os.environ.get("OPENAI_API_KEY", "")}, "sleep for 2 seconds", True)
-print(messages)


### PR DESCRIPTION
## Problem

Benchmark run results were previously saved to a file called `output.csv`.  This was a problem because:
- subsequent runs would overwrite `output.csv`, deleting previous runs, and
- it was too easy to accidentally commit `output.csv` to the repo.

## Solution

Benchmark results and datasets are now saved to a `.local` directory, which is excluded by `.gitignore`.  Going forward, this directory should be used to store anything that is helpful to have on users' local machines that should not be in the repo.