### PR TITLE
Custom tasks

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -10,7 +10,7 @@ import shlex
 import time
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from queue import Queue
 from threading import Thread
 from abc import ABC, abstractmethod
@@ -330,9 +330,9 @@ Did the student get the answer correct?
 @dataclass
 class OIBenchmarks:
     benchmark: Benchmark
-    modifier: TaskSetModifier
     command: OpenInterpreterCommand
-    runner: BenchmarkRunner
+    runner: BenchmarkRunner = field(default_factory=DockerBenchmarkRunner)
+    modifier: TaskSetModifier = field(default_factory=IdModifier)
     nworkers: Optional[int] = None
 
     def run(self) -> List[TaskResult]:

--- a/custom.py
+++ b/custom.py
@@ -11,7 +11,7 @@ from typing import List, TypedDict, cast
 import jsonschema
 import jsonschema.validators
 
-from benchmark import LMC, Benchmark, LoadedTask, ResultStatus, ZeroShotTask, judge_result
+from benchmark import LMC, TasksStore, LoadedTask, ResultStatus, ZeroShotTask, judge_result
 
 
 CUSTOM_TASK_SCHEMA = {
@@ -54,15 +54,15 @@ class LoadedCustomTask(LoadedTask[CustomTask]):
 
 
 @dataclass
-class CustomBenchmark(Benchmark[CustomTask]):
+class CustomTasks(TasksStore[CustomTask]):
     tasks: List[CustomTask] = field(default_factory=list)
 
     @staticmethod
-    def from_list(l: List[CustomTask]) -> "CustomBenchmark":
-        return CustomBenchmark(l)
+    def from_list(l: List[CustomTask]) -> "CustomTasks":
+        return CustomTasks(l)
     
     @staticmethod
-    def from_csv(path: PathLike) -> "CustomBenchmark":
+    def from_csv(path: PathLike) -> "CustomTasks":
         rows: List[CustomTask] = []
         if Path(path).exists():
             with open(path, "r") as file:
@@ -72,7 +72,7 @@ class CustomBenchmark(Benchmark[CustomTask]):
                     rows.append(cast(CustomTask, row))
         else:
             raise FileNotFoundError(f"'{path}' does not exist, so it can't be used to load a CustomBenchmark.")
-        return CustomBenchmark(rows)
+        return CustomTasks(rows)
 
     def get_tasks(self) -> List[CustomTask]:
         return self.tasks

--- a/custom.py
+++ b/custom.py
@@ -1,0 +1,81 @@
+"""
+For defining a custom set of benchmarks.
+"""
+
+import csv
+from dataclasses import dataclass, field
+from os import PathLike
+from pathlib import Path
+from typing import List, TypedDict, cast
+
+import jsonschema
+import jsonschema.validators
+
+from benchmark import LMC, Benchmark, LoadedTask, ResultStatus, ZeroShotTask, judge_result
+
+
+CUSTOM_TASK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": { "type": "string" },
+        "prompt": { "type": "string" },
+        "answer": { "type": "string" },
+    }
+}
+
+
+class CustomTask(TypedDict):
+    id: str
+    prompt: str
+    answer: str
+
+
+@dataclass
+class LoadedCustomTask(LoadedTask[CustomTask]):
+    task: CustomTask
+
+    def to_zero_shot(self) -> ZeroShotTask:
+        return {"id": self.task["id"], "prompt": self.task["prompt"]}
+
+    def to_result_status(self, messages: List[LMC]) -> ResultStatus:
+        if len(messages) == 0:
+            return "unknown"
+        final_message = messages[-1]
+        if "role" not in final_message:
+            return "unknown"
+        if final_message["role"] == "error":
+            return "error"
+        if "content" not in final_message:
+            return "unknown"
+        
+        expected = self.task["answer"]
+        prompt = self.to_zero_shot()["prompt"]
+        return judge_result(prompt, final_message["content"], expected)
+
+
+@dataclass
+class CustomBenchmark(Benchmark[CustomTask]):
+    tasks: List[CustomTask] = field(default_factory=list)
+
+    @staticmethod
+    def from_list(l: List[CustomTask]) -> "CustomBenchmark":
+        return CustomBenchmark(l)
+    
+    @staticmethod
+    def from_csv(path: PathLike) -> "CustomBenchmark":
+        rows: List[CustomTask] = []
+        if Path(path).exists():
+            with open(path, "r") as file:
+                reader = csv.DictReader(file)
+                for row in reader:
+                    jsonschema.validate(row, CUSTOM_TASK_SCHEMA)
+                    rows.append(cast(CustomTask, row))
+        else:
+            raise FileNotFoundError(f"'{path}' does not exist, so it can't be used to load a CustomBenchmark.")
+        return CustomBenchmark(rows)
+
+    def get_tasks(self) -> List[CustomTask]:
+        return self.tasks
+        
+    def load_task(self, task: CustomTask) -> LoadedTask[CustomTask]:
+        return LoadedCustomTask(task)

--- a/gaia.py
+++ b/gaia.py
@@ -5,7 +5,7 @@ from datasets import load_dataset
 from fsspec import AbstractFileSystem, filesystem
 from interpreter import OpenInterpreter
 
-from benchmark import LMC, Benchmark, LoadedTask, ResultStatus, TaskResult, TaskSetModifier, ZeroShotTask, judge_result
+from benchmark import LMC, TasksStore, LoadedTask, ResultStatus, TaskResult, TaskSetModifier, ZeroShotTask, judge_result
 from constants import DATASETS, GAIA
 from utils import copy_between_fss, wrapping_offset
 
@@ -52,7 +52,7 @@ class LoadedGAIATask(LoadedTask[GAIATask]):
         return judge_result(prompt, final_message["content"], expected)
 
 
-class GAIABenchmark(Benchmark[GAIATask]):
+class GAIATasks(TasksStore[GAIATask]):
     def get_tasks(self) -> List[GAIATask]:
         ds = load_dataset(str(GAIA), "2023_all", split="validation", data_dir=str(DATASETS), trust_remote_code=True)
         tasks = cast(List[GAIATask], list(ds))

--- a/gaia.py
+++ b/gaia.py
@@ -5,7 +5,7 @@ from datasets import load_dataset
 from fsspec import AbstractFileSystem, filesystem
 from interpreter import OpenInterpreter
 
-from benchmark import LMC, Benchmark, LoadedTask, ResultStatus, TaskResult, ZeroShotTask
+from benchmark import LMC, Benchmark, LoadedTask, ResultStatus, TaskResult, TaskSetModifier, ZeroShotTask, judge_result
 from constants import DATASETS, GAIA
 from utils import copy_between_fss, wrapping_offset
 
@@ -19,37 +19,6 @@ GAIATask = TypedDict("GAIATask", {
     "file_path": str,
     "Annotator Metadata": Optional[Dict[str, str]]
 })
-
-
-def judge_result(initial_prompt: str, last_msg: str, expected: str) -> ResultStatus:
-    judge = OpenInterpreter()
-    judge.llm.model = "gpt-4"
-    judge.llm.context_window = 128000  # type: ignore
-
-    judge.system_message = "You are a grading AI. Answer with the single word 'correct' or 'incorrect', and do NOT answer in markdown."
-    q = f"""
-    
-# QUESTION:
-{initial_prompt}
-# CORRECT ANSWER:
-{expected}
----
-# STUDENT'S ANSWER:
-{last_msg}
----
-
-Did the student get the answer correct?
-
-    """.strip()
-    
-    judge_msgs = cast(List[LMC], judge.chat(q, display=False))
-    assert len(judge_msgs) > 0, "the judge is speechless!"
-
-    judge_result = judge_msgs[0]["content"].strip()
-    assert judge_result in {"correct", "incorrect", "unknown", "error"}, f"the judge's response was unexpected! response: {judge_result}"
-
-    judge.computer.terminate()
-    return judge_result  # type: ignore
 
 
 @dataclass
@@ -82,28 +51,12 @@ class LoadedGAIATask(LoadedTask[GAIATask]):
         prompt = self.to_zero_shot()["prompt"]
         return judge_result(prompt, final_message["content"], expected)
 
-        # final_answer_re = re.search("FINAL ANSWER: (.+)", final_message["content"])
-        # if final_answer_re is None:
-        #     return "unknown"
-
-        # actual = final_answer_re.group(1).strip()
-        # if actual.lower() != expected.lower():
-        #     return "incorrect"
-        # else:
-        #     return "correct"
-
 
 class GAIABenchmark(Benchmark[GAIATask]):
-    def __init__(self, first_n: Optional[int] = None, offset: int = 0, predicates: List[Callable[[GAIATask], bool]] = []):
-        self.first_n = first_n
-        self.offset = offset
-        self.predicates = predicates
-
     def get_tasks(self) -> List[GAIATask]:
         ds = load_dataset(str(GAIA), "2023_all", split="validation", data_dir=str(DATASETS), trust_remote_code=True)
         tasks = cast(List[GAIATask], list(ds))
-        n_tasks = self.first_n or len(tasks)
-        return wrapping_offset([t for t in tasks if all(p(t) for p in self.predicates)], self.offset, n_tasks)
+        return tasks
         
     def load_task(self, task: GAIATask) -> LoadedTask[GAIATask]:
         return LoadedGAIATask(task)

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -64,15 +64,12 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        # benchmark=GAIABenchmark(),
         benchmark=CustomBenchmark.from_list([
             {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
             {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
         ]),
-        # benchmark=CustomBenchmark.from_csv(DATASETS / "custom" / "debug.csv"),
         modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
-        runner=DockerBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import List, Optional
 
 from constants import DATASETS
-from custom import CustomBenchmark
+from custom import CustomTasks
 from benchmark import DockerBenchmarkRunner, OIBenchmarks, SizeOffsetModifier, TaskResult
 from commands import commands
-from gaia import GAIABenchmark
+from gaia import GAIATasks
 
 
 def save_results(results: List[TaskResult], filepath: Path):
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        benchmark=CustomBenchmark.from_list([
+        tasks=CustomTasks.from_list([
             {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
             {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
         ]),

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -9,6 +9,7 @@ from constants import DATASETS
 from custom import CustomBenchmark
 from benchmark import DockerBenchmarkRunner, OIBenchmarks, SizeOffsetModifier, TaskResult
 from commands import commands
+from gaia import GAIABenchmark
 
 
 def save_results(results: List[TaskResult], filepath: Path):
@@ -64,11 +65,11 @@ if __name__ == "__main__":
 
     results = OIBenchmarks(
         # benchmark=GAIABenchmark(),
-        # benchmark=CustomBenchmark.from_list([
-        #     {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
-        #     {"id": "hard", "prompt": "who do you think you are??", "answer": "iamlaptop"},
-        # ]),
-        benchmark=CustomBenchmark.from_csv(DATASETS / "custom" / "debug.csv"),
+        benchmark=CustomBenchmark.from_list([
+            {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
+            {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
+        ]),
+        # benchmark=CustomBenchmark.from_csv(DATASETS / "custom" / "debug.csv"),
         modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         runner=DockerBenchmarkRunner()

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
         ]),
         modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
+        nworkers=args.nworkers
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')


### PR DESCRIPTION
## Problem

GAIA only is bad.  We want custom.

## Solution

We got custom.

- Changed the run script to use a new `OIBenchmarks` object which mostly configures command, benchmark, task count and offset stuff.
- Added a `CustomTasks` drop-in replacement for `GAIATasks` (what was previously `GAIABenchmark`.
- Example usage:
```python
    results = OIBenchmarks(
        benchmark=CustomTask.from_list([
            {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
            {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
        ]),
        command=commands["gpt4o"]
    ).run()
```