### PR TITLE
Output less spammy

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -598,11 +598,13 @@ def run_benchmark_worker_pool_with_server(
         lambda ext:
             Spinner("dots", style="yellow", text=
                 Text(f"task ")
-                    .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                    # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                    .append(f"http://{host}:{port}/view/{ext}")
                     .append(": ...")),
         lambda ext, r:
             Text(f"🏁 task ")
-                .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                .append(f"http://{host}:{port}/view/{ext}")
                 .append(f": {status_character(r['status'])}")
     )
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -600,13 +600,13 @@ def run_benchmark_worker_pool_with_server(
         lambda ext:
             Spinner("dots", style="yellow", text=
                 Text(f"task ")
-                    .append(ext, style=f"link http://{host}:{port}/view/{ext}")
-                    # .append(f"http://{host}:{port}/view/{ext}")
+                    # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                    .append(f"http://{host}:{port}/view/{ext}")
                     .append(": ...")),
         lambda ext, r:
             Text(f"🏁 task ")
-                .append(ext, style=f"link http://{host}:{port}/view/{ext}")
-                # .append(f"http://{host}:{port}/view/{ext}")
+                # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                .append(f"http://{host}:{port}/view/{ext}")
                 .append(f": {status_character(r['status'])}")
     )
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -150,7 +150,7 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
                 command_json_str, f"{shlex.quote(prompt)}", worker_dir, output_dir
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while p.poll() is None and p.stdout is not None:
-                write(p.stdout.read())
+                write(p.stdout.readline())
 
             messages_path = worker_dir / worker.OUTPUT_PATH
             with open(messages_path, "r") as f:
@@ -181,7 +181,7 @@ class DockerBenchmarkRunner(BenchmarkRunner):
             # subprocess.run(dcmd, stdout=subprocess.DEVNULL)
             p = subprocess.Popen(dcmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while p.poll() is None and p.stdout is not None:
-                write(p.stdout.read())
+                write(p.stdout.readline())
 
             messages_path = Path(temp_dir) / worker.OUTPUT_PATH
             if not messages_path.exists():
@@ -595,12 +595,10 @@ def run_benchmark_worker_pool_with_server(
         lambda ext:
             Spinner("dots", style="yellow", text=
                 Text(f"task ")
-                    # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
                     .append(f"http://{host}:{port}/view/{ext}")
                     .append(": ...")),
         lambda ext, r:
             Text(f"🏁 task ")
-                # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
                 .append(f"http://{host}:{port}/view/{ext}")
                 .append(f": {status_character(r['status'])}")
     )

--- a/benchmark.py
+++ b/benchmark.py
@@ -150,6 +150,7 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
                 command_json_str, f"{shlex.quote(prompt)}", worker_dir, output_dir
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while p.poll() is None and p.stdout is not None:
+                print("wrigint?")
                 write(p.stdout.readline())
 
             messages_path = worker_dir / worker.OUTPUT_PATH
@@ -598,13 +599,13 @@ def run_benchmark_worker_pool_with_server(
         lambda ext:
             Spinner("dots", style="yellow", text=
                 Text(f"task ")
-                    # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
-                    .append(f"http://{host}:{port}/view/{ext}")
+                    .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                    # .append(f"http://{host}:{port}/view/{ext}")
                     .append(": ...")),
         lambda ext, r:
             Text(f"🏁 task ")
-                # .append(ext, style=f"link http://{host}:{port}/view/{ext}")
-                .append(f"http://{host}:{port}/view/{ext}")
+                .append(ext, style=f"link http://{host}:{port}/view/{ext}")
+                # .append(f"http://{host}:{port}/view/{ext}")
                 .append(f": {status_character(r['status'])}")
     )
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -239,6 +239,7 @@ def run_task(lt: LoadedTask[Task], command: OpenInterpreterCommand, runner: Benc
 
 
 Result = TypeVar("Result")
+_P = ParamSpec("_P")
 
 
 class TaskDisplay(Generic[Result]):
@@ -250,7 +251,7 @@ class TaskDisplay(Generic[Result]):
         self._started_ids: List[Tuple[int, str]] = []
         self._results: Dict[int, Result] = {}
 
-    def wrap[**_P](self, fn: Callable[_P, Result], ext_str: str) -> Callable[_P, Result]:
+    def wrap(self, fn: Callable[_P, Result], ext_str: str) -> Callable[_P, Result]:
         def wrapped_fn(*args, **kwargs):
             ident = id(wrapped_fn)
             self._started(ident, ext_str)

--- a/benchmark.py
+++ b/benchmark.py
@@ -133,7 +133,7 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
 
             command_json_str = json.dumps(command)
             subprocess.run(["python", "-m", "worker.run", command_json_str, f"{shlex.quote(prompt)}", output_dir], cwd=worker_dir)
-            messages_path = output_dir / worker.OUTPUT_PATH
+            messages_path = worker_dir / worker.OUTPUT_PATH
             with open(messages_path, "r") as f:
                 messages = json.load(f)
                 return messages

--- a/benchmark.py
+++ b/benchmark.py
@@ -563,7 +563,6 @@ def run_benchmark_worker_pool_with_server(
 
     def run_task(lt: LoadedTask[Task], zs: ZeroShotTask, session: TaskSession) -> TaskResult:
         def write(b: bytes):
-            print(b, end="")
             asyncio.run(session.write(b))
 
         start = datetime.now()

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import json
 import logging
 import os
@@ -17,7 +16,7 @@ from queue import Queue
 from threading import Thread
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Callable, Coroutine, Dict, Generic, Iterable, List, Literal, NotRequired, Optional, ParamSpec, Tuple, TypeVar, TypedDict, cast, override
+from typing import Any, Callable, Dict, Generic, List, Literal, NotRequired, Optional, ParamSpec, Tuple, TypeVar, TypedDict, cast
 from fsspec import AbstractFileSystem
 from interpreter import OpenInterpreter
 from rich.spinner import Spinner
@@ -27,7 +26,7 @@ from rich.spinner import Spinner
 from rich.text import Text
 from rich.padding import Padding
 
-from utils import LocalBasedFS, change_working_dir, wrapping_offset
+from utils import LocalBasedFS, wrapping_offset
 import worker
 
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -586,7 +586,7 @@ def run_benchmark_worker_pool_with_server(
                 "status": status
             }
         
-    config = uvicorn.Config(app, log_level="info")
+    config = uvicorn.Config(app, log_level="warning")
     host, port = config.host, config.port
     server = Server(config=config)
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -132,7 +132,10 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
             lt.setup_input_dir(LocalBasedFS(str(input_dir)))
 
             command_json_str = json.dumps(command)
-            subprocess.run(["python", "-m", "worker.run", command_json_str, f"{shlex.quote(prompt)}", output_dir], cwd=worker_dir)
+            subprocess.run([
+                "python", "-m", "worker.run",
+                # command_json_str, f"{shlex.quote(prompt)}", output_dir
+            ], cwd=worker_dir)
             messages_path = worker_dir / worker.OUTPUT_PATH
             with open(messages_path, "r") as f:
                 messages = json.load(f)

--- a/benchmark.py
+++ b/benchmark.py
@@ -134,8 +134,8 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
             command_json_str = json.dumps(command)
             subprocess.run([
                 "python", "-m", "worker.run",
-                # command_json_str, f"{shlex.quote(prompt)}", output_dir
-            ], cwd=worker_dir)
+                command_json_str, f"{shlex.quote(prompt)}", worker_dir, output_dir
+            ])
             messages_path = worker_dir / worker.OUTPUT_PATH
             with open(messages_path, "r") as f:
                 messages = json.load(f)
@@ -162,7 +162,7 @@ class DockerBenchmarkRunner(BenchmarkRunner):
                 "-v", f"{input_dir}:/input", "-v", f"{output_dir}:/output",
                 "--name", container_name,
                 DockerBenchmarkRunner.WORKER_NAME,
-                command_json_str, f"{shlex.quote(prompt)}", "/output"
+                command_json_str, f"{shlex.quote(prompt)}", "/", "/output"
             ]
             subprocess.run(dcmd, stdout=subprocess.DEVNULL)
             messages_path = Path(temp_dir) / worker.OUTPUT_PATH

--- a/benchmark.py
+++ b/benchmark.py
@@ -151,7 +151,6 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while p.poll() is None and p.stdout is not None:
                 line = p.stdout.readline()
-                print("wrigint?", line)
                 write(line)
 
             messages_path = worker_dir / worker.OUTPUT_PATH
@@ -505,6 +504,7 @@ class TaskSession:
         with self._lock:
             for b in bs:
                 self._history.append(b)
+            print("writing?", bs)
             await self._broadcast(bs)
 
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -153,7 +153,7 @@ class DockerBenchmarkRunner(BenchmarkRunner):
             input_dir.mkdir(parents=True, exist_ok=True)
             output_dir.mkdir(parents=True, exist_ok=True)
             lt.setup_input_dir(LocalBasedFS(str(input_dir)))
-            container_name = f"{lt.to_zero_shot()["id"]}_{time.time()}"
+            container_name = f"{lt.to_zero_shot()['id']}_{time.time()}"
             dcmd = [
                 "docker", "run", "-t",
                 "-v", f"{input_dir}:/input", "-v", f"{output_dir}:/output",

--- a/benchmark.py
+++ b/benchmark.py
@@ -586,7 +586,7 @@ def run_benchmark_worker_pool_with_server(
                 "status": status
             }
         
-    config = uvicorn.Config(app, log_level="error")
+    config = uvicorn.Config(app, log_level="info")
     host, port = config.host, config.port
     server = Server(config=config)
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -150,8 +150,9 @@ class DefaultBenchmarkRunner(BenchmarkRunner):
                 command_json_str, f"{shlex.quote(prompt)}", worker_dir, output_dir
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while p.poll() is None and p.stdout is not None:
-                print("wrigint?")
-                write(p.stdout.readline())
+                line = p.stdout.readline()
+                print("wrigint?", line)
+                write(line)
 
             messages_path = worker_dir / worker.OUTPUT_PATH
             with open(messages_path, "r") as f:

--- a/gaia.py
+++ b/gaia.py
@@ -60,3 +60,8 @@ class GAIATasks(TasksStore[GAIATask]):
         
     def load_task(self, task: GAIATask) -> LoadedTask[GAIATask]:
         return LoadedGAIATask(task)
+
+
+class GAIAFilesOnlyModifier(TaskSetModifier[GAIATask]):
+    def modify(self, task_set: List[GAIATask]) -> List[GAIATask]:
+        return [t for t in task_set if t["file_name"] != ""]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ jsonschema
 git+https://github.com/imapersonman/open-interpreter.git@main
 fsspec
 uvicorn
+websockets
 rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ datasets
 jsonschema
 git+https://github.com/imapersonman/open-interpreter.git@main
 fsspec
+uvicorn
+rich

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -7,9 +7,9 @@ from typing import List, Optional
 
 from constants import DATASETS
 from custom import CustomTasks
-from benchmark import DockerBenchmarkRunner, OIBenchmarks, SizeOffsetModifier, TaskResult
+from benchmark import DefaultBenchmarkRunner, DockerBenchmarkRunner, ModifierPipe, OIBenchmarks, SizeOffsetModifier, TaskResult
 from commands import commands
-from gaia import GAIATasks
+from gaia import GAIAFilesOnlyModifier, GAIATasks
 
 
 def save_results(results: List[TaskResult], filepath: Path):
@@ -68,9 +68,14 @@ if __name__ == "__main__":
             {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
             {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
         ]),
-        modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
+        modifier=ModifierPipe([
+            GAIAFilesOnlyModifier(),
+            SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)
+        ]),
+        # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
-        nworkers=args.nworkers
+        nworkers=args.nworkers,
+        runner=DefaultBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -64,11 +64,11 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        # tasks=CustomTasks.from_list([
-        #     {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
-        #     {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
-        # ]),
-        tasks=GAIATasks(),
+        tasks=CustomTasks.from_list([
+            {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
+            {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
+        ]),
+        # tasks=GAIATasks(),
         modifier=ModifierPipe([
             # GAIAFilesOnlyModifier(),
             SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -64,10 +64,11 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        tasks=CustomTasks.from_list([
-            {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
-            {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
-        ]),
+        # tasks=CustomTasks.from_list([
+        #     {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
+        #     {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
+        # ]),
+        tasks=GAIATasks(),
         modifier=ModifierPipe([
             GAIAFilesOnlyModifier(),
             SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -37,6 +37,7 @@ class ArgumentsNamespace(argparse.Namespace):
     ntasks: Optional[int]
     task_offset: int
     nworkers: Optional[int]
+    server: bool
 
 
 if __name__ == "__main__":
@@ -49,6 +50,7 @@ if __name__ == "__main__":
     parser.add_argument("-nt", "--ntasks", action="store", type=int)
     parser.add_argument("-nw", "--nworkers", action="store", type=int)
     parser.add_argument("-to", "--task-offset", action="store", type=int, default=0)
+    parser.add_argument("-s", "--server", action="store_true")
     args = parser.parse_args(namespace=ArgumentsNamespace())
 
     if args.list:
@@ -77,7 +79,8 @@ if __name__ == "__main__":
         command=commands[args.command],
         nworkers=args.nworkers,
         # runner=DefaultBenchmarkRunner()
-        runner=DockerBenchmarkRunner()
+        runner=DockerBenchmarkRunner(),
+        server=args.server
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
         # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         nworkers=args.nworkers,
-        # runner=DefaultBenchmarkRunner()
-        runner=DockerBenchmarkRunner()
+        runner=DefaultBenchmarkRunner()
+        # runner=DockerBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
         # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         nworkers=args.nworkers,
-        runner=DefaultBenchmarkRunner()
-        # runner=DockerBenchmarkRunner()
+        # runner=DefaultBenchmarkRunner()
+        runner=DockerBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -70,13 +70,14 @@ if __name__ == "__main__":
         # ]),
         tasks=GAIATasks(),
         modifier=ModifierPipe([
-            GAIAFilesOnlyModifier(),
+            # GAIAFilesOnlyModifier(),
             SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)
         ]),
         # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         nworkers=args.nworkers,
-        runner=DefaultBenchmarkRunner()
+        # runner=DefaultBenchmarkRunner()
+        runner=DockerBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -64,11 +64,11 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        tasks=CustomTasks.from_list([
-            {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
-            {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
-        ]),
-        # tasks=GAIATasks(),
+        # tasks=CustomTasks.from_list([
+        #     {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
+        #     {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
+        # ]),
+        tasks=GAIATasks(),
         modifier=ModifierPipe([
             # GAIAFilesOnlyModifier(),
             SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)
@@ -76,8 +76,8 @@ if __name__ == "__main__":
         # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         nworkers=args.nworkers,
-        runner=DefaultBenchmarkRunner()
-        # runner=DockerBenchmarkRunner()
+        # runner=DefaultBenchmarkRunner()
+        runner=DockerBenchmarkRunner()
     ).run()
 
     correct_count = sum(1 for result in results if result['status'] == 'correct')

--- a/templates/logs.html.j2
+++ b/templates/logs.html.j2
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>task {{ task_id }}</title>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
+    </head>
+    <body>
+        <h1>Task {{ task_id }}</h1>
+        
+        <div id="terminal"></div>
+        <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
+        <script>
+            const terminal = new Terminal();
+            terminal.open(document.getElementById('terminal'));
+            const ws = new WebSocket("{{ url_for("logs", task_id=task_id) }}")
+            ws.onmessage = (event) => {
+                const logs_el = document.getElementById('logs')
+                event.data.text().then((txt) => {
+                    terminal.write(txt)
+                })
+            }
+        </script>
+    </body>
+</html>

--- a/templates/logs.html.j2
+++ b/templates/logs.html.j2
@@ -10,16 +10,29 @@
         <div id="terminal"></div>
         <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
         <script>
-            const terminal = new Terminal({ convertEol: true });
+            const terminal = new Terminal({ convertEol: true, rendererType: 'webgl', cursorBlink: false });
             terminal.open(document.getElementById('terminal'));
             const ws = new WebSocket("{{ url_for("logs", task_id=task_id) }}")
+
+            /*
             ws.onmessage = (event) => {
-                const logs_el = document.getElementById('logs')
                 terminal.write(event.data)
-                // event.data.text().then((txt) => {
-                //     terminal.write(txt)
-                // })
             }
+            */
+
+            let buffer = '';
+            const flushInterval = 100;
+
+            setInterval(() => {
+                if (buffer) {
+                    terminal.write(buffer)
+                    buffer = ''
+                }
+            }, flushInterval);
+
+            ws.onmessage = (event) => {
+                buffer += event.data
+            };
         </script>
     </body>
 </html>

--- a/templates/logs.html.j2
+++ b/templates/logs.html.j2
@@ -10,14 +10,15 @@
         <div id="terminal"></div>
         <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
         <script>
-            const terminal = new Terminal();
+            const terminal = new Terminal({ convertEol: true });
             terminal.open(document.getElementById('terminal'));
             const ws = new WebSocket("{{ url_for("logs", task_id=task_id) }}")
             ws.onmessage = (event) => {
                 const logs_el = document.getElementById('logs')
-                event.data.text().then((txt) => {
-                    terminal.write(txt)
-                })
+                terminal.write(event.data)
+                // event.data.text().then((txt) => {
+                //     terminal.write(txt)
+                // })
             }
         </script>
     </body>

--- a/worker/run.py
+++ b/worker/run.py
@@ -22,8 +22,8 @@ if __name__ == "__main__":
         }
     }
 
-    if len(sys.argv) != 4:
-        print("Usage: python -m worker.run <command:json-str> <prompt:str> <output-dir:str>")
+    if len(sys.argv) != 5:
+        print("Usage: python -m worker.run <command:json-str> <prompt:str> <cwd:str> <output-dir:str>")
         exit(1)
 
     # grabbing command.
@@ -34,8 +34,12 @@ if __name__ == "__main__":
     # grabbing prompt.
     prompt = sys.argv[2]
 
+    # grabbing the current working directory this script is to use.
+    cwd = sys.argv[3]
+    os.chdir(cwd)
+
     # grabbing output directory.
-    out_dir = Path(sys.argv[3])
+    out_dir = Path(sys.argv[4])
     print("output dir:", out_dir)
 
     print("command config:")


### PR DESCRIPTION
## Problem

The output used to spam the terminal, especially when running the `DefaultBenchmarkRunner`.

## Solution

- Use rich to condense task status updates.
- Added some server endpoints for viewing stdout and stderr of task processes as they're running.
    - Accessible via the `-s` or `--server` command line flag.